### PR TITLE
fix(ci): use KV instead of secrets for deployment metadata

### DIFF
--- a/.github/workflows/deploy-to-cloudflare-workers.yml
+++ b/.github/workflows/deploy-to-cloudflare-workers.yml
@@ -56,17 +56,9 @@ jobs:
           echo "DEPLOYMENT_ID=$DEPLOYMENT_ID" >> "$GITHUB_ENV"
           echo "Deployment ID: $DEPLOYMENT_ID"
 
-      - name: Print new cloudflare deployment id
-        run: |
-          echo "Current Deployment ID: $DEPLOYMENT_ID"
-
-      - name: Set new cloudflare deployment id
+      - name: Save deployment ID to KV
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           accountId: ${{ secrets.CF_ACCOUNT_ID }}
-          command: deployments status
-          postCommands: |
-            echo "*** get the cloudflare deployment id ***"
-            echo "${{ env.DEPLOYMENT_ID }}" | wrangler secret put CF_DEPLOYMENT_ID
-            echo "******"
+          command: kv:key put --binding=CONFIG "DEPLOYMENT_ID" "${{ env.DEPLOYMENT_ID }}"

--- a/.github/workflows/deploy-to-cloudflare-workers.yml
+++ b/.github/workflows/deploy-to-cloudflare-workers.yml
@@ -42,11 +42,6 @@ jobs:
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           accountId: ${{ secrets.CF_ACCOUNT_ID }}
-          preCommands: |
-            echo "*** update last commit variables ***"
-            echo "${{ env.COMMIT_HASH_FULL }}" | wrangler secret put LAST_COMMIT
-            echo "${{ env.COMMIT_HASH_SHORT }}" | wrangler secret put LAST_COMMIT_SHORT
-            echo "******"
 
       - name: Get new cloudflare deployment id
         env:
@@ -56,9 +51,12 @@ jobs:
           echo "DEPLOYMENT_ID=$DEPLOYMENT_ID" >> "$GITHUB_ENV"
           echo "Deployment ID: $DEPLOYMENT_ID"
 
-      - name: Save deployment ID to KV
+      - name: Save deployment metadata to KV
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           accountId: ${{ secrets.CF_ACCOUNT_ID }}
           command: kv:key put --binding=CONFIG "DEPLOYMENT_ID" "${{ env.DEPLOYMENT_ID }}"
+          postCommands: |
+            wrangler kv:key put --binding=CONFIG "LAST_COMMIT" "${{ env.COMMIT_HASH_FULL }}"
+            wrangler kv:key put --binding=CONFIG "LAST_COMMIT_SHORT" "${{ env.COMMIT_HASH_SHORT }}"

--- a/src/commands/slash/stats.ts
+++ b/src/commands/slash/stats.ts
@@ -11,8 +11,10 @@ import { EmbedBuilder } from '@discordjs/builders';
 
 import packageJson from '@/../package.json';
 import { APP_GITHUB, APP_VERSION, EMBED_COLOR } from '@/lib/constants';
+import { getDeploymentId } from '@/lib/config';
 import { getUserProfile } from '@/lib/utils';
 import { errorEmbedBuilder } from '@/ui';
+import { Env } from '@/types';
 import { UserResponseError } from '@/types/user';
 
 type OptionTypes = {
@@ -55,13 +57,15 @@ export default class StatsSlashCommand extends SlashCommand {
 
     await ctx.defer(ephemeral);
 
-    const appInfo = await ctx.creator.requestHandler.request<APIApplication>('GET', '/applications/@me', {
-      auth: true
-    });
+    const env = this.creator.client as Env;
 
-    const COMMIT_HASH = this.creator.client.LAST_COMMIT;
-    const COMMIT_HASH_SHORT = this.creator.client.LAST_COMMIT_SHORT;
-    const CF_DEPLOYMENT_ID = this.creator.client.CF_DEPLOYMENT_ID.split('-')[0];
+    const [appInfo, deploymentId] = await Promise.all([
+      ctx.creator.requestHandler.request<APIApplication>('GET', '/applications/@me', { auth: true }),
+      getDeploymentId(env)
+    ]);
+
+    const COMMIT_HASH = env.LAST_COMMIT;
+    const COMMIT_HASH_SHORT = env.LAST_COMMIT_SHORT;
 
     const guildCount = appInfo.approximate_guild_count;
     const slashCreateVersion = packageJson.devDependencies['slash-create'];
@@ -82,7 +86,7 @@ export default class StatsSlashCommand extends SlashCommand {
         },
         {
           name: 'Deployment',
-          value: `\`${CF_DEPLOYMENT_ID}\``,
+          value: `\`${deploymentId}\``,
           inline: true
         },
         {

--- a/src/commands/slash/stats.ts
+++ b/src/commands/slash/stats.ts
@@ -11,7 +11,7 @@ import { EmbedBuilder } from '@discordjs/builders';
 
 import packageJson from '@/../package.json';
 import { APP_GITHUB, APP_VERSION, EMBED_COLOR } from '@/lib/constants';
-import { getDeploymentId } from '@/lib/config';
+import { getCommitHash, getCommitHashShort, getDeploymentId } from '@/lib/config';
 import { getUserProfile } from '@/lib/utils';
 import { errorEmbedBuilder } from '@/ui';
 import { Env } from '@/types';
@@ -59,13 +59,12 @@ export default class StatsSlashCommand extends SlashCommand {
 
     const env = this.creator.client as Env;
 
-    const [appInfo, deploymentId] = await Promise.all([
+    const [appInfo, deploymentId, commitHash, commitHashShort] = await Promise.all([
       ctx.creator.requestHandler.request<APIApplication>('GET', '/applications/@me', { auth: true }),
-      getDeploymentId(env)
+      getDeploymentId(env),
+      getCommitHash(env),
+      getCommitHashShort(env)
     ]);
-
-    const COMMIT_HASH = env.LAST_COMMIT;
-    const COMMIT_HASH_SHORT = env.LAST_COMMIT_SHORT;
 
     const guildCount = appInfo.approximate_guild_count;
     const slashCreateVersion = packageJson.devDependencies['slash-create'];
@@ -81,7 +80,7 @@ export default class StatsSlashCommand extends SlashCommand {
         },
         {
           name: 'Version',
-          value: `${APP_VERSION} [\`[${COMMIT_HASH_SHORT}]\`](${APP_GITHUB}/commit/${COMMIT_HASH})`,
+          value: `${APP_VERSION} [\`[${commitHashShort}]\`](${APP_GITHUB}/commit/${commitHash})`,
           inline: true
         },
         {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { SlashCreator, CloudflareWorkerServer } from 'slash-create/web';
 import { commands } from './commands';
 import { Env } from '@/types';
 import { CommandStatEntry } from '@safepeek/utils';
+import { getCommitHashShort } from '@/lib/config';
 import { makeCommandStatRequest } from '@/lib/fetch';
 import { errorEmbedBuilder } from '@/ui';
 import { APP_VERSION } from '@/lib/constants';
@@ -40,7 +41,7 @@ function makeCreator(env: Env) {
         interaction_id: ctx.interactionID,
         invoked_at: ctx.invokedAt,
         bot_version: APP_VERSION,
-        last_commit: env.LAST_COMMIT_SHORT,
+        last_commit: await getCommitHashShort(env),
         environment: env.NODE_ENV
       }
     };

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,10 +1,26 @@
 import { Env } from '@/types';
 
 let cachedDeploymentId: string | null = null;
+let cachedCommitHash: string | null = null;
+let cachedCommitHashShort: string | null = null;
 
 export async function getDeploymentId(env: Env): Promise<string> {
   if (cachedDeploymentId) return cachedDeploymentId;
 
   cachedDeploymentId = (await env.CONFIG.get('DEPLOYMENT_ID')) ?? 'unknown';
   return cachedDeploymentId;
+}
+
+export async function getCommitHash(env: Env): Promise<string> {
+  if (cachedCommitHash) return cachedCommitHash;
+
+  cachedCommitHash = (await env.CONFIG.get('LAST_COMMIT')) ?? 'unknown';
+  return cachedCommitHash;
+}
+
+export async function getCommitHashShort(env: Env): Promise<string> {
+  if (cachedCommitHashShort) return cachedCommitHashShort;
+
+  cachedCommitHashShort = (await env.CONFIG.get('LAST_COMMIT_SHORT')) ?? 'unknown';
+  return cachedCommitHashShort;
 }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,0 +1,10 @@
+import { Env } from '@/types';
+
+let cachedDeploymentId: string | null = null;
+
+export async function getDeploymentId(env: Env): Promise<string> {
+  if (cachedDeploymentId) return cachedDeploymentId;
+
+  cachedDeploymentId = (await env.CONFIG.get('DEPLOYMENT_ID')) ?? 'unknown';
+  return cachedDeploymentId;
+}

--- a/src/types/globals.d.ts
+++ b/src/types/globals.d.ts
@@ -7,7 +7,6 @@ declare const NODE_ENV: string;
 declare const GOOGLE_API_KEY: string;
 declare const LAST_COMMIT: string;
 declare const LAST_COMMIT_SHORT: string;
-declare const CF_DEPLOYMENT_ID: string;
 declare const API_KEY: string;
 declare const API_BASE_ROUTE: string;
 declare const GITHUB_TOKEN: string;

--- a/src/types/globals.d.ts
+++ b/src/types/globals.d.ts
@@ -5,8 +5,6 @@ declare const DISCORD_BOT_TOKEN: string;
 declare const DEVELOPMENT_GUILD_ID: string;
 declare const NODE_ENV: string;
 declare const GOOGLE_API_KEY: string;
-declare const LAST_COMMIT: string;
-declare const LAST_COMMIT_SHORT: string;
 declare const API_KEY: string;
 declare const API_BASE_ROUTE: string;
 declare const GITHUB_TOKEN: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,8 +4,6 @@ export type Env = {
   DISCORD_BOT_TOKEN: string;
   DEVELOPMENT_GUILD_ID: string;
   GOOGLE_API_KEY: string;
-  LAST_COMMIT: string;
-  LAST_COMMIT_SHORT: string;
   NODE_ENV: string;
   API_KEY: string;
   API_BASE_ROUTE: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,9 +6,9 @@ export type Env = {
   GOOGLE_API_KEY: string;
   LAST_COMMIT: string;
   LAST_COMMIT_SHORT: string;
-  CF_DEPLOYMENT_ID: string;
   NODE_ENV: string;
   API_KEY: string;
   API_BASE_ROUTE: string;
   GITHUB_TOKEN: string;
+  CONFIG: KVNamespace;
 };

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -5,6 +5,10 @@ compatibility_flags = ["nodejs_compat"]
 
 vars = { NODE_ENV = "production" }
 
+[[kv_namespaces]]
+binding = "CONFIG"
+id = "016a364fc2854b758ee01504fdf01b72"
+
 [env.development]
 
 [placement]


### PR DESCRIPTION
## Summary

- Store deployment ID, commit hash, and commit hash short in Workers KV instead of Cloudflare secrets
- Add in-memory caching to avoid KV reads on every request
- Eliminate extra deployments triggered by secret changes

## Problem

Saving deployment metadata as Cloudflare secrets triggers new deployments, making the captured values stale immediately. For example, saving the deployment ID as a secret would create a new deployment, so the stored ID no longer matched the running deployment.

## Solution

Use Workers KV for storage instead. KV writes don't trigger redeployments, so the captured values remain accurate. Added a CONFIG KV namespace with simple caching helpers that store values in memory after the first KV read per isolate.

## Test plan

- [x] Deploy to Cloudflare Workers
- [x] Verify `/stats` command shows correct deployment ID
- [x] Verify commit hash links to correct commit on GitHub
- [x] Confirm only one deployment is created per release (no "Secret Change" deployments)

Closes #3

🤖 Generated with [Claude Code](https://claude.ai/code)