### PR TITLE
fix(commands): defer ephemeral preference resolution with layered cache

### DIFF
--- a/src/commands/message/analyze.ts
+++ b/src/commands/message/analyze.ts
@@ -28,7 +28,7 @@ import {
 } from '@/ui';
 import { analyzeUrlRequest } from '@/lib/fetch';
 import { analyzeUrl, truncate } from '@/lib/urls';
-import { getUserProfile } from '@/lib/utils';
+import { resolveEphemeral } from '@/lib/cache';
 import {
   AnalyzeUrlError,
   AnalyzeUrlResponse,
@@ -39,7 +39,7 @@ import {
 } from '@/types/url';
 import { ThreatMatchResponse } from '@/types/google';
 import { checkUrlsForThreats } from '@/lib/google';
-import { UserResponseError } from '@/types/user';
+import { Env } from '@/types';
 
 type HandleUrlProps = {
   ctx: ComponentContext | CommandContext;
@@ -64,14 +64,8 @@ export default class AnalyzeMessageCommand extends SlashCommand {
   }
 
   async run(ctx: CommandContext) {
-    const profile = await getUserProfile({
-      creator: this.creator,
-      ctx
-    });
-
-    if (!profile.ok) throw new Error((profile as UserResponseError).data.code);
-
-    const ephemeral = profile.data.ephemeral ?? true;
+    const env = this.creator.client as Env;
+    const ephemeral = await resolveEphemeral(ctx.user.id, env);
 
     await ctx.defer(ephemeral);
 

--- a/src/commands/slash/analyze.ts
+++ b/src/commands/slash/analyze.ts
@@ -21,11 +21,11 @@ import {
   threatEmbedNoHits
 } from '@/ui';
 import { analyzeUrl } from '@/lib/urls';
-import { getUserProfile } from '@/lib/utils';
+import { resolveEphemeral } from '@/lib/cache';
 import { ThreatMatchResponse } from '@/types/google';
 import { checkUrlsForThreats } from '@/lib/google';
 import { AnalyzeUrlError, AnalyzeUrlResponse, AnalyzeUrlSuccess } from '@/types/url';
-import { UserResponseError } from '@/types/user';
+import { Env } from '@/types';
 
 type OptionTypes = {
   url: string;
@@ -62,15 +62,9 @@ export default class AnalyzeSlashCommand extends SlashCommand {
   }
 
   async run(ctx: CommandContext) {
-    const profile = await getUserProfile({
-      creator: this.creator,
-      ctx
-    });
-
-    if (!profile.ok) throw new Error((profile as UserResponseError).data.code);
-
+    const env = this.creator.client as Env;
     const options = ctx.options as OptionTypes;
-    const ephemeral = options.ephemeral ?? profile.data.ephemeral ?? true;
+    const ephemeral = options.ephemeral ?? (await resolveEphemeral(ctx.user.id, env));
 
     await ctx.defer(ephemeral);
 

--- a/src/commands/slash/changelog.ts
+++ b/src/commands/slash/changelog.ts
@@ -10,9 +10,9 @@ import {
   SlashCreator
 } from 'slash-create/web';
 import { EmbedBuilder } from '@discordjs/builders';
-import { getUserProfile } from '@/lib/utils';
+import { resolveEphemeral } from '@/lib/cache';
 import { errorEmbedBuilder } from '@/ui';
-import { UserResponseError } from '@/types/user';
+import { Env } from '@/types';
 import { makeGitHubAPIRequest } from '@/lib/fetch';
 import { APP_GITHUB, APP_VERSION, EMBED_COLOR } from '@/lib/constants';
 
@@ -44,15 +44,9 @@ export default class ChangelogSlashCommand extends SlashCommand {
   }
 
   async run(ctx: CommandContext) {
-    const profile = await getUserProfile({
-      creator: this.creator,
-      ctx
-    });
-
-    if (!profile.ok) throw new Error((profile as UserResponseError).data.code);
-
+    const env = this.creator.client as Env;
     const options = ctx.options as OptionTypes;
-    const ephemeral = options.ephemeral ?? profile.data.ephemeral ?? true;
+    const ephemeral = options.ephemeral ?? (await resolveEphemeral(ctx.user.id, env));
 
     await ctx.defer(ephemeral);
 

--- a/src/commands/slash/help.ts
+++ b/src/commands/slash/help.ts
@@ -11,10 +11,10 @@ import {
 import { EmbedBuilder } from '@discordjs/builders';
 import { stripIndents } from 'common-tags';
 
-import { getUserProfile } from '@/lib/utils';
+import { resolveEphemeral } from '@/lib/cache';
 import { APP_NAME, EMBED_COLOR, WEBSITE } from '@/lib/constants';
 import { errorEmbedBuilder } from '@/ui';
-import { UserResponseError } from '@/types/user';
+import { Env } from '@/types';
 
 type OptionTypes = {
   ephemeral: boolean | undefined;
@@ -44,15 +44,9 @@ export default class HelpSlashCommand extends SlashCommand {
   }
 
   async run(ctx: CommandContext) {
-    const profile = await getUserProfile({
-      creator: this.creator,
-      ctx
-    });
-
-    if (!profile.ok) throw new Error((profile as UserResponseError).data.code);
-
+    const env = this.creator.client as Env;
     const options = ctx.options as OptionTypes;
-    const ephemeral = options.ephemeral ?? profile.data.ephemeral ?? true;
+    const ephemeral = options.ephemeral ?? (await resolveEphemeral(ctx.user.id, env));
 
     const analyzeSlashCommandId: string =
       this.creator.client.NODE_ENV === 'production' ? '1210526106634027019' : '1210506556710588487';

--- a/src/commands/slash/invite.ts
+++ b/src/commands/slash/invite.ts
@@ -8,9 +8,9 @@ import {
 } from 'slash-create/web';
 
 import { APP_NAME, GUILD_INSTALL_LINK, USER_INSTALL_LINK } from '@/lib/constants';
-import { getUserProfile } from '@/lib/utils';
+import { resolveEphemeral } from '@/lib/cache';
 import { errorEmbedBuilder } from '@/ui';
-import { UserResponseError } from '@/types/user';
+import { Env } from '@/types';
 import { stripIndents } from 'common-tags';
 
 type OptionTypes = {
@@ -41,15 +41,9 @@ export default class InviteSlashCommand extends SlashCommand {
   }
 
   async run(ctx: CommandContext) {
-    const profile = await getUserProfile({
-      creator: this.creator,
-      ctx
-    });
-
-    if (!profile.ok) throw new Error((profile as UserResponseError).data.code);
-
+    const env = this.creator.client as Env;
     const options = ctx.options as OptionTypes;
-    const ephemeral = options.ephemeral ?? profile.data.ephemeral ?? true;
+    const ephemeral = options.ephemeral ?? (await resolveEphemeral(ctx.user.id, env));
 
     return ctx.send({
       content: stripIndents`

--- a/src/commands/slash/ping.ts
+++ b/src/commands/slash/ping.ts
@@ -6,9 +6,9 @@ import {
   CommandOptionType,
   InteractionContextType
 } from 'slash-create/web';
-import { getUserProfile } from '@/lib/utils';
+import { resolveEphemeral } from '@/lib/cache';
 import { errorEmbedBuilder } from '@/ui';
-import { UserResponseError } from '@/types/user';
+import { Env } from '@/types';
 
 type OptionTypes = {
   ephemeral: boolean | undefined;
@@ -38,15 +38,9 @@ export default class PingSlashCommand extends SlashCommand {
   }
 
   async run(ctx: CommandContext) {
-    const profile = await getUserProfile({
-      creator: this.creator,
-      ctx
-    });
-
-    if (!profile.ok) throw new Error((profile as UserResponseError).data.code);
-
+    const env = this.creator.client as Env;
     const options = ctx.options as OptionTypes;
-    const ephemeral = options.ephemeral ?? profile.data.ephemeral ?? true;
+    const ephemeral = options.ephemeral ?? (await resolveEphemeral(ctx.user.id, env));
 
     return ctx.send({
       content: 'Pong!',

--- a/src/commands/slash/profile.ts
+++ b/src/commands/slash/profile.ts
@@ -12,8 +12,10 @@ import { EmbedBuilder } from '@discordjs/builders';
 
 import { EMBED_COLOR } from '@/lib/constants';
 import { getUserProfile, updateUserProfile } from '@/lib/utils';
+import { cacheEphemeral } from '@/lib/cache';
 import { EmbedAuthor } from 'slash-create/lib/structures/message';
 import { errorEmbedBuilder } from '@/ui';
+import { Env } from '@/types';
 import { UserResponseError, UserResponseSuccess } from '@/types/user';
 
 type OptionTypes = {
@@ -51,6 +53,8 @@ export default class ProfileSlashCommand extends SlashCommand {
       icon_url: ctx.user.avatarURL
     };
 
+    const env = this.creator.client as Env;
+
     let ephemeral: boolean;
     if (options.ephemeral !== undefined) {
       const userProfile = await updateUserProfile({
@@ -67,6 +71,8 @@ export default class ProfileSlashCommand extends SlashCommand {
       if (!userProfile.ok) throw new Error((userProfile as UserResponseError).data.code);
 
       ephemeral = userProfile.data.ephemeral!;
+
+      await cacheEphemeral(ctx.user.id, ephemeral, env);
 
       const embed: APIEmbed = new EmbedBuilder()
         .setColor(EMBED_COLOR)

--- a/src/commands/slash/support.ts
+++ b/src/commands/slash/support.ts
@@ -8,9 +8,9 @@ import {
 } from 'slash-create/web';
 
 import { DISCORD_INVITE } from '@/lib/constants';
-import { getUserProfile } from '@/lib/utils';
+import { resolveEphemeral } from '@/lib/cache';
 import { errorEmbedBuilder } from '@/ui';
-import { UserResponseError } from '@/types/user';
+import { Env } from '@/types';
 
 type OptionTypes = {
   ephemeral: boolean | undefined;
@@ -40,15 +40,9 @@ export default class SupportSlashCommand extends SlashCommand {
   }
 
   async run(ctx: CommandContext) {
-    const profile = await getUserProfile({
-      creator: this.creator,
-      ctx
-    });
-
-    if (!profile.ok) throw new Error((profile as UserResponseError).data.code);
-
+    const env = this.creator.client as Env;
     const options = ctx.options as OptionTypes;
-    const ephemeral = options.ephemeral ?? profile.data.ephemeral ?? true;
+    const ephemeral = options.ephemeral ?? (await resolveEphemeral(ctx.user.id, env));
 
     return ctx.send({
       content: DISCORD_INVITE,

--- a/src/commands/slash/vote.ts
+++ b/src/commands/slash/vote.ts
@@ -10,9 +10,9 @@ import {
   SlashCreator
 } from 'slash-create/web';
 import { EmbedBuilder } from '@discordjs/builders';
-import { getUserProfile } from '@/lib/utils';
+import { resolveEphemeral } from '@/lib/cache';
 import { errorEmbedBuilder } from '@/ui';
-import { UserResponseError } from '@/types/user';
+import { Env } from '@/types';
 import { APP_NAME, BOT_LISTS, EMBED_COLOR } from '@/lib/constants';
 
 type OptionTypes = {
@@ -43,15 +43,9 @@ export default class VoteSlashCommand extends SlashCommand {
   }
 
   async run(ctx: CommandContext) {
-    const profile = await getUserProfile({
-      creator: this.creator,
-      ctx
-    });
-
-    if (!profile.ok) throw new Error((profile as UserResponseError).data.code);
-
+    const env = this.creator.client as Env;
     const options = ctx.options as OptionTypes;
-    const ephemeral = options.ephemeral ?? profile.data.ephemeral ?? true;
+    const ephemeral = options.ephemeral ?? (await resolveEphemeral(ctx.user.id, env));
 
     const embed = new EmbedBuilder()
       .setDescription(`You may view below each bot list site and where **\`${APP_NAME}\`** is listed for voting.`)

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -1,0 +1,36 @@
+import { Env } from '@/types';
+import { makeProfileRequest } from '@/lib/fetch';
+
+const ephemeralCache = new Map<string, boolean>();
+
+export async function resolveEphemeral(userId: string, env: Env): Promise<boolean> {
+  if (ephemeralCache.has(userId)) return ephemeralCache.get(userId)!;
+
+  const kvValue = await env.USER_CACHE.get(`ephemeral:${userId}`);
+  if (kvValue !== null) {
+    const resolved = kvValue === 'true';
+    ephemeralCache.set(userId, resolved);
+    return resolved;
+  }
+
+  // Cache miss — default to true and populate in the background
+  populateEphemeralCache(userId, env);
+  return true;
+}
+
+export async function cacheEphemeral(userId: string, value: boolean, env: Env): Promise<void> {
+  ephemeralCache.set(userId, value);
+  await env.USER_CACHE.put(`ephemeral:${userId}`, String(value));
+}
+
+function populateEphemeralCache(userId: string, env: Env): void {
+  makeProfileRequest({ method: 'get', discordUserId: userId }, env)
+    .then((response) => {
+      const resolved = response.ok ? (response.data.ephemeral ?? true) : true;
+      ephemeralCache.set(userId, resolved);
+      env.USER_CACHE.put(`ephemeral:${userId}`, String(resolved));
+    })
+    .catch(() => {
+      ephemeralCache.set(userId, true);
+    });
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -9,4 +9,5 @@ export type Env = {
   API_BASE_ROUTE: string;
   GITHUB_TOKEN: string;
   CONFIG: KVNamespace;
+  USER_CACHE: KVNamespace;
 };

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -9,6 +9,10 @@ vars = { NODE_ENV = "production" }
 binding = "CONFIG"
 id = "016a364fc2854b758ee01504fdf01b72"
 
+[[kv_namespaces]]
+binding = "USER_CACHE"
+id = "83debe59d30c4b92ae726ef5fcd39842"
+
 [env.development]
 
 [placement]


### PR DESCRIPTION
## Summary

- Replace pre-ACK API call to Neon with a layered cache (`in-memory Map` → `Workers KV` → `default true`) to resolve ephemeral preference before Discord's ~3s interaction window expires
- Add `USER_CACHE` KV namespace and `src/lib/cache.ts` with `resolveEphemeral()`, `cacheEphemeral()`, and background cache population on miss
- Add write-through caching on `/profile` ephemeral update (Neon → KV → in-memory)

## Test plan

- [x] Run `/ping` and verify response uses correct ephemeral preference
- [x] Run `/profile ephemeral:false` to update preference, then run another command to confirm it respects the new value
- [x] Verify cold start behavior: on first interaction after deploy, ephemeral defaults to `true` and background populates cache for subsequent requests

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)